### PR TITLE
推送sdk版本升级更新

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,8 +5,8 @@ plugins {
 }
 
 gradle.ext {
-    pushVersion = '3.8.6'
-    thirdPushVersion = '3.8.6'
+    pushVersion = '3.8.8.1'
+    thirdPushVersion = '3.8.8'
 }
 
 android {
@@ -92,7 +92,7 @@ dependencies {
     api "com.aliyun.ams:alicloud-android-third-push-meizu:${gradle.thirdPushVersion}"
     api "com.aliyun.ams:alicloud-android-third-push-vivo:${gradle.thirdPushVersion}"
     api "com.aliyun.ams:alicloud-android-third-push-oppo:${gradle.thirdPushVersion}"
-    api "com.aliyun.ams:alicloud-android-third-push-xiaomi:3.8.6.1"
+    api "com.aliyun.ams:alicloud-android-third-push-xiaomi:${gradle.thirdPushVersion}"
     api "com.aliyun.ams:alicloud-android-third-push-huawei:${gradle.thirdPushVersion}"
     api "com.aliyun.ams:alicloud-android-third-push-honor:${gradle.thirdPushVersion}"
     api "com.aliyun.ams:alicloud-android-third-push-fcm:${gradle.thirdPushVersion}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,8 +5,8 @@ plugins {
 }
 
 gradle.ext {
-    pushVersion = '3.8.8.1'
-    thirdPushVersion = '3.8.8'
+    pushVersion = '3.9.0'
+    thirdPushVersion = '3.9.0'
 }
 
 android {

--- a/app/src/main/java/com/alibaba/ams/emas/demo/ui/advance/AdvanceFragment.kt
+++ b/app/src/main/java/com/alibaba/ams/emas/demo/ui/advance/AdvanceFragment.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.alibaba.ams.emas.demo.ui.IShowDialog
 import com.alibaba.sdk.android.push.CloudPushService
 import com.alibaba.sdk.android.push.CommonCallback
-import com.alibaba.sdk.android.tool.NetworkUtils
+//import com.alibaba.sdk.android.tool.NetworkUtils
 import com.aliyun.emas.pocdemo.R
 import com.aliyun.emas.pocdemo.databinding.FragmentAdvanceBinding
 import com.google.android.material.chip.Chip
@@ -78,19 +78,19 @@ class AdvanceFragment : Fragment(), IShowDialog {
         }
 
         binding.advanceBoundAccount.setOnCloseIconClickListener {
-            if (!NetworkUtils.isNetworkConnected(activity)) {
-                toast(getString(R.string.network_not_connect))
-            } else {
+//            if (!NetworkUtils.isNetworkConnected(activity)) {
+//                toast(getString(R.string.network_not_connect))
+//            } else {
                 viewModel.unbindAccount()
-            }
+//            }
         }
 
         binding.advanceBoundPhone.setOnCloseIconClickListener {
-            if (!NetworkUtils.isNetworkConnected(activity)) {
-                toast(getString(R.string.network_not_connect))
-            } else {
+//            if (!NetworkUtils.isNetworkConnected(activity)) {
+//                toast(getString(R.string.network_not_connect))
+//            } else {
                 viewModel.unbindPhone()
-            }
+//            }
         }
         return root
     }
@@ -231,10 +231,10 @@ class AdvanceFragment : Fragment(), IShowDialog {
     }
 
     private fun bindAccount() {
-        if (!NetworkUtils.isNetworkConnected(activity)) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(activity)) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
         val input = LayoutInflater.from(activity).inflate(R.layout.dialog_input, null)
         val editText = input.findViewById<AppCompatEditText>(R.id.add_input)
         editText.hint = getString(R.string.account_hint)
@@ -259,10 +259,10 @@ class AdvanceFragment : Fragment(), IShowDialog {
     }
 
     private fun addTag(target: Int) {
-        if (!NetworkUtils.isNetworkConnected(activity)) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(activity)) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
         val input = LayoutInflater.from(activity).inflate(R.layout.dialog_input, null)
         val editText = input.findViewById<AppCompatEditText>(R.id.add_input)
         editText.hint = getString(R.string.tag_hint)
@@ -323,10 +323,10 @@ class AdvanceFragment : Fragment(), IShowDialog {
     }
 
     private fun addAliasTag(alias: String) {
-        if (!NetworkUtils.isNetworkConnected(activity)) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(activity)) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
         val input = LayoutInflater.from(activity).inflate(R.layout.dialog_input, null)
         val editText = input.findViewById<AppCompatEditText>(R.id.add_input)
         editText.hint = getString(R.string.tag_hint)
@@ -350,10 +350,10 @@ class AdvanceFragment : Fragment(), IShowDialog {
     }
 
     private fun unbindDeviceTag(tag: String, view: View) {
-        if (!NetworkUtils.isNetworkConnected(activity)) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(activity)) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
         viewModel.removeDeviceTag(tag, object : CommonCallback {
             override fun onSuccess(response: String?) {
                 //remove view
@@ -372,10 +372,10 @@ class AdvanceFragment : Fragment(), IShowDialog {
     }
 
     private fun unbindAccountTag(tag: String, view: View) {
-        if (!NetworkUtils.isNetworkConnected(activity)) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(activity)) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
         viewModel.removeAccountTag(tag, object : CommonCallback {
             override fun onSuccess(response: String?) {
                 //remove view
@@ -394,10 +394,10 @@ class AdvanceFragment : Fragment(), IShowDialog {
     }
 
     private fun unbindAliasTag(tag: String, alias: String, view: View) {
-        if (!NetworkUtils.isNetworkConnected(activity)) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(activity)) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
         viewModel.removeAliasTag(tag, alias, object : CommonCallback {
             override fun onSuccess(response: String?) {
                 //remove view
@@ -417,10 +417,10 @@ class AdvanceFragment : Fragment(), IShowDialog {
 
     private fun addAlias() {
 
-        if (!NetworkUtils.isNetworkConnected(activity)) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(activity)) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
 
         val input = LayoutInflater.from(activity).inflate(R.layout.dialog_input, null)
         val editText = input.findViewById<AppCompatEditText>(R.id.add_input)
@@ -446,10 +446,10 @@ class AdvanceFragment : Fragment(), IShowDialog {
     }
 
     private fun removeAlias(alias: String, view: View) {
-        if (!NetworkUtils.isNetworkConnected(activity)) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(activity)) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
         viewModel.removeAlias(
             alias,
             object : CommonCallback {
@@ -472,10 +472,10 @@ class AdvanceFragment : Fragment(), IShowDialog {
 
 
     private fun bindPhoneNumber() {
-        if (!NetworkUtils.isNetworkConnected(activity)) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(activity)) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
         val input = LayoutInflater.from(activity).inflate(R.layout.dialog_input, null)
         val editText = input.findViewById<AppCompatEditText>(R.id.add_input)
         editText.hint = getString(R.string.phone_hint)

--- a/app/src/main/java/com/alibaba/ams/emas/demo/ui/basic/BasicViewModel.kt
+++ b/app/src/main/java/com/alibaba/ams/emas/demo/ui/basic/BasicViewModel.kt
@@ -16,7 +16,7 @@ import com.alibaba.ams.emas.demo.SingleLiveData
 import com.alibaba.sdk.android.push.CloudPushService
 import com.alibaba.sdk.android.push.CommonCallback
 import com.alibaba.sdk.android.push.noonesdk.PushServiceFactory
-import com.alibaba.sdk.android.tool.NetworkUtils
+//import com.alibaba.sdk.android.tool.NetworkUtils
 import com.aliyun.emas.pocdemo.R
 import kotlinx.coroutines.launch
 
@@ -70,9 +70,9 @@ class BasicViewModel(
     }
 
     fun checkPushStatus() {
-        if (!NetworkUtils.isNetworkConnected(getApplication())) {
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(getApplication())) {
+//            return
+//        }
         cloudPushService.checkPushChannelStatus(object : CommonCallback {
             override fun onSuccess(response: String?) {
                 pushChannelOpenedData.value = true
@@ -86,10 +86,10 @@ class BasicViewModel(
 
 
     fun registerPush() {
-        if (!NetworkUtils.isNetworkConnected(getApplication())) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(getApplication())) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
         cloudPushService.register(getApplication(), object : CommonCallback {
             override fun onSuccess(response: String?) {
                 Toast.makeText(
@@ -112,10 +112,10 @@ class BasicViewModel(
 
 
     fun openPush() {
-        if (!NetworkUtils.isNetworkConnected(getApplication())) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(getApplication())) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
         cloudPushService.turnOnPushChannel(object : CommonCallback {
             override fun onSuccess(response: String?) {
                 pushChannelOpenedData.value = true
@@ -140,10 +140,10 @@ class BasicViewModel(
     }
 
     fun closePush() {
-        if (!NetworkUtils.isNetworkConnected(getApplication())) {
-            toast(getString(R.string.network_not_connect))
-            return
-        }
+//        if (!NetworkUtils.isNetworkConnected(getApplication())) {
+//            toast(getString(R.string.network_not_connect))
+//            return
+//        }
         cloudPushService.turnOffPushChannel(object : CommonCallback {
             override fun onSuccess(response: String?) {
                 pushChannelOpenedData.value = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+#?????????AndroidX?
+android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-#?????????AndroidX?
-android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 #Thu May 11 10:39:20 CST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+#gradle?????????
+distributionUrl=https://emas-devops-cdn.aliyuncs.com/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 #Thu May 11 10:39:20 CST 2023
 distributionBase=GRADLE_USER_HOME
-#gradle?????????
 distributionUrl=https://emas-devops-cdn.aliyuncs.com/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
1.推送sdk版本由3.8.6升级到3.8.8.1。
2.厂商辅助通道sdk版本升级到3.8.8。
3.gradle下载镜像替换成阿里镜像路径，避免访问google下载卡主。